### PR TITLE
Add support for scheduled events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DISCORD_TOKEN=your-token-here
 # The database to connect to
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:9232/wafflebot?schema=public
 
+# The NATS JetStream instance to connect to
+NATS_URL=nats://127.0.0.1:9242
+
 # The token for authenticating with the application portal
 APPLICATION_PORTAL_BASE_URL=https://127.0.0.1:8000
 APPLICATION_PORTAL_TOKEN=some-token-here

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ NODE_ENV=development
 # The Discord bot token to login with
 DISCORD_TOKEN=your-token-here
 
+# The ID of the guild the bot operates in
+DISCORD_GUILD_ID=1234567890
+
 # The database to connect to
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:9232/wafflebot?schema=public
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ services:
     networks:
       - default
 
+  nats:
+    image: nats:2.9.18-alpine
+    command:
+      - -a=0.0.0.0
+      - -p=4222
+      - --jetstream
+    ports:
+      - "9243:4222"
+
   jaeger:
     image: jaegertracing/all-in-one:1.45
     ports:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sapphire/framework": "^4.4.4",
     "discord.js": "14.x",
     "dotenv": "^16.1.3",
+    "nats": "^2.15.0",
     "node-cache": "^5.1.2",
     "opentelemetry-instrumentation-node-cache": "^0.35.0",
     "prisma": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@prisma/client": "^4.15.0",
     "@prisma/instrumentation": "^4.15.0",
     "@sapphire/framework": "^4.4.4",
+    "date-fns": "^2.30.0",
     "discord.js": "14.x",
     "dotenv": "^16.1.3",
     "nats": "^2.15.0",

--- a/prisma/migrations/20230620035848_add_events_table/migration.sql
+++ b/prisma/migrations/20230620035848_add_events_table/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "events" (
+    "id" INTEGER NOT NULL,
+    "discord_id" TEXT NOT NULL,
+
+    CONSTRAINT "events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "events_discord_id_key" ON "events"("discord_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,3 +36,11 @@ model Link {
   discord_id String @id
   participant_id Int @unique
 }
+
+// Mapping from portal event ID to Discord scheduled event ID
+model Event {
+  @@map("events")
+
+  id Int @id
+  discord_id String @unique
+}

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -45,7 +45,7 @@ export class NextCommand extends Command {
 
     let embed: EmbedBuilder;
     if (next) {
-      embed = embeds.card(next.name);
+      embed = embeds.card(next.name, next.description || undefined);
 
       const discordId = await Event.find(next.id);
       if (discordId) embed.setURL(`https://discord.com/events/${GUILD_ID}/${discordId}`);

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -1,0 +1,78 @@
+import { CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import { formatDistance, getUnixTime, millisecondsToSeconds, parseISO } from 'date-fns';
+import { EmbedBuilder } from 'discord.js';
+
+import { GUILD_ID } from '@lib/config';
+import { Event } from '@lib/database';
+import embeds from '@lib/embeds';
+import { EventDetails, listEvents } from '@lib/portal';
+import { Command } from '@lib/sapphire';
+import { withSpan, withSyncSpan } from '@lib/tracing';
+
+// Cache for an hour
+const CACHE_DURATION = 60 * 60;
+
+export class NextCommand extends Command {
+  // Allow caching event list for an hour
+  private events: EventDetails[] = [];
+  private lastFetched = 0;
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Get details about the next event',
+      runIn: CommandOptionsRunTypeEnum.GuildText,
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder //
+        .setName(this.name)
+        .setDescription(this.description),
+    );
+  }
+
+  public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+    await withSpan('reply.defer', () => interaction.deferReply());
+
+    const events = await withSpan('fetch-events', () => this.fetchEvents());
+
+    const next: EventDetails | undefined = withSyncSpan('find-next', () => {
+      const now = millisecondsToSeconds(Date.now());
+      return events.find((e) => getUnixTime(parseISO(e.start)) > now);
+    });
+
+    let embed: EmbedBuilder;
+    if (next) {
+      embed = embeds.card(next.name);
+
+      const discordId = await Event.find(next.id);
+      if (discordId) embed.setURL(`https://discord.com/events/${GUILD_ID}/${discordId}`);
+
+      const start = parseISO(next.start);
+      const end = parseISO(next.end);
+
+      embed.addFields(
+        { name: 'Starts', value: `<t:${getUnixTime(start)}:R>`, inline: true },
+        { name: 'Duration', value: formatDistance(end, start), inline: true },
+      );
+    } else {
+      embed = embeds.card(
+        'WaffleHacks has ended!',
+        'Unfortunately there are no more workshops or panels. We look forward to seeing you again next year!',
+      );
+    }
+
+    await withSpan('reply.edit', () => interaction.editReply({ embeds: [embed] }));
+  }
+
+  private async fetchEvents(): Promise<EventDetails[]> {
+    if (Date.now() < this.lastFetched + CACHE_DURATION) return this.events;
+
+    this.events = await listEvents();
+    this.lastFetched = Date.now();
+
+    return this.events;
+  }
+}

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,0 +1,67 @@
+import { CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import { getUnixTime, parseISO } from 'date-fns';
+
+import { GUILD_ID } from '@lib/config';
+import { Event } from '@lib/database';
+import embeds from '@lib/embeds';
+import { EventDetails, listEvents } from '@lib/portal';
+import { Command } from '@lib/sapphire';
+import { withSpan } from '@lib/tracing';
+
+// Cache for an hour
+const CACHE_DURATION = 60 * 60;
+
+export class ScheduleCommand extends Command {
+  // Allow caching event list for an hour
+  private events = '';
+  private lastFetched = 0;
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Get the schedule for the hackathon',
+      runIn: CommandOptionsRunTypeEnum.GuildText,
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName(this.name).setDescription(this.description).setDMPermission(false),
+    );
+  }
+
+  public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+    await withSpan('reply.defer', () => interaction.deferReply());
+
+    const events = await withSpan('fetch-events', async () => await this.fetchEvents());
+    await withSpan('reply.edit', () => interaction.editReply({ embeds: [embeds.card('Events', events)] }));
+  }
+
+  private async fetchEvents(): Promise<string> {
+    if (Date.now() < this.lastFetched + CACHE_DURATION) return this.events;
+
+    const events = await listEvents();
+    const formatted = await Promise.all(
+      events.map((event) =>
+        withSpan('format', (span) => {
+          span.setAttribute('event.id', event.id);
+          return this.formatEvent(event);
+        }),
+      ),
+    );
+    this.events = formatted.join('\n');
+
+    this.lastFetched = Date.now();
+
+    return this.events;
+  }
+
+  private async formatEvent(event: EventDetails): Promise<string> {
+    const start = parseISO(event.start);
+    const timestamp = getUnixTime(start);
+
+    const discordId = await Event.find(event.id);
+    if (discordId) return `<t:${timestamp}:f> - [${event.name}](https://discord.com/events/${GUILD_ID}/${discordId})`;
+    else return `<t:${timestamp}:f> - ${event.name}`;
+  }
+}

--- a/src/commands/sync-events.ts
+++ b/src/commands/sync-events.ts
@@ -1,0 +1,56 @@
+import { CommandOptionsRunTypeEnum } from '@sapphire/framework';
+
+import { Event } from '@lib/database';
+import embeds from '@lib/embeds';
+import { listEvents } from '@lib/portal';
+import { Command } from '@lib/sapphire';
+import * as scheduledEvents from '@lib/scheduled-events';
+import { withSpan } from '@lib/tracing';
+
+export class SyncEventsCommand extends Command {
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Sync the events in the application portal with the Discord events',
+      runIn: CommandOptionsRunTypeEnum.GuildText,
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder //
+        .setName(this.name)
+        .setDescription(this.description),
+    );
+  }
+
+  public override async chatInputRun(interaction: Command.ChatInputCommandInteraction) {
+    await withSpan('reply.defer', () => interaction.deferReply({ ephemeral: true }));
+
+    const eventMappings = await withSpan('event-mappings', () => this.fetchEventMapping());
+    const events = await listEvents();
+
+    const client = this.container.client;
+
+    for (const event of events) {
+      const discordId = eventMappings[event.id.toString()];
+
+      if (discordId) await scheduledEvents.update(client, event, discordId);
+      else await scheduledEvents.create(client, event);
+
+      delete eventMappings[event.id.toString()];
+    }
+
+    for (const id of Object.values(eventMappings)) await scheduledEvents.remove(client, id);
+
+    await withSpan('reply.edit', () =>
+      interaction.editReply({ embeds: [embeds.message('Successfully synced events from application portal')] }),
+    );
+  }
+
+  private async fetchEventMapping(): Promise<Record<string, string>> {
+    const events = await Event.list();
+    const entries = events.map((e) => [e.id.toString(), e.discord_id]);
+    return Object.fromEntries(entries);
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,8 @@ export const TOKEN = load('DISCORD_TOKEN');
 export const APPLICATION_PORTAL_URL = load('APPLICATION_PORTAL_BASE_URL');
 export const APPLICATION_PORTAL_TOKEN = load('APPLICATION_PORTAL_TOKEN');
 
+export const NATS_URL = load('NATS_URL');
+
 export const HEALTHCHECK_ADDRESS = process.env.HEALTHCHECK_ADDRESS;
 export const HEALTHCHECK_PORT = parseInt(load('HEALTHCHECK_PORT', '8888'));
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,6 +11,7 @@ function load(name: string, defaultValue?: string): string {
 }
 
 export const TOKEN = load('DISCORD_TOKEN');
+export const GUILD_ID = load('DISCORD_GUILD_ID');
 
 export const APPLICATION_PORTAL_URL = load('APPLICATION_PORTAL_BASE_URL');
 export const APPLICATION_PORTAL_TOKEN = load('APPLICATION_PORTAL_TOKEN');

--- a/src/lib/database/event.ts
+++ b/src/lib/database/event.ts
@@ -18,7 +18,11 @@ export class Event {
    * @param discordId the Discord scheduled event ID
    */
   public static async create(id: number, discordId: string) {
-    await prisma.event.create({ data: { id, discord_id: discordId } });
+    await prisma.event.upsert({
+      create: { id, discord_id: discordId },
+      where: { id },
+      update: { discord_id: discordId },
+    });
   }
 
   /**

--- a/src/lib/database/event.ts
+++ b/src/lib/database/event.ts
@@ -1,0 +1,31 @@
+import { prisma } from './client';
+
+export class Event {
+  /**
+   * Find the Discord scheduled event ID by an event's application portal id
+   * @param id the application portal ID
+   */
+  public static async find(id: number): Promise<string | null> {
+    const event = await prisma.event.findFirst({ where: { id } });
+    if (event === null) return null;
+
+    return event.discord_id;
+  }
+
+  /**
+   * Create a new event mapping from application portal event to Discord scheduled event
+   * @param id the application portal ID
+   * @param discordId the Discord scheduled event ID
+   */
+  public static async create(id: number, discordId: string) {
+    await prisma.event.create({ data: { id, discord_id: discordId } });
+  }
+
+  /**
+   * Delete an event mapping by an event's scheduled event ID
+   * @param discordId the scheduled event ID
+   */
+  public static async delete(discordId: string) {
+    await prisma.event.delete({ where: { discord_id: discordId } });
+  }
+}

--- a/src/lib/database/event.ts
+++ b/src/lib/database/event.ts
@@ -1,6 +1,18 @@
 import { prisma } from './client';
 
+interface DatabaseEvent {
+  id: number;
+  discord_id: string;
+}
+
 export class Event {
+  /**
+   * Get a list of all the mapped discord events
+   */
+  public static async list(): Promise<DatabaseEvent[]> {
+    return prisma.event.findMany();
+  }
+
   /**
    * Find the Discord scheduled event ID by an event's application portal id
    * @param id the application portal ID

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -1,3 +1,4 @@
 export { prisma as default } from './client';
+export { Event } from './event';
 export { Link } from './link';
 export { Settings } from './settings';

--- a/src/lib/nats/client.ts
+++ b/src/lib/nats/client.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events';
+
+import { JsMsg, NatsConnection, NatsError, connect, consumerOpts, createInbox } from 'nats';
+
+import { NATS_URL } from '@lib/config';
+import logger, { Logger } from '@lib/logger';
+import { VERSION } from '@lib/version';
+
+export default class NATS extends EventEmitter {
+  private server: NatsConnection | null = null;
+  private topics: Set<string> = new Set();
+
+  private logger: Logger = logger.child('nats');
+
+  private async connect(): Promise<NatsConnection> {
+    return await connect({
+      name: `wafflebot/${VERSION}`,
+      reconnect: true,
+      servers: NATS_URL,
+    });
+  }
+
+  public override on(eventName: string | symbol, listener: (...args: any[]) => void): this {
+    // intentionally ignoring promise
+    this.listen(eventName.toString());
+
+    return super.on(eventName, listener);
+  }
+
+  public override once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+    // intentionally ignoring promise
+    this.listen(eventName.toString());
+
+    return super.once(eventName, listener);
+  }
+
+  private async listen(topic: string) {
+    if (this.server === null) this.server = await this.connect();
+
+    // already registered, nothing to do
+    if (this.topics.has(topic)) return;
+
+    try {
+      const jetStream = this.server.jetstream();
+      await jetStream.subscribe(
+        topic,
+        consumerOpts()
+          .durable(topic.replaceAll('.', '-'))
+          .queue(topic.replaceAll('.', '-'))
+          .manualAck()
+          .ackExplicit()
+          .deliverTo(createInbox('wafflebot-'))
+          .callback(this.consumerCallback.bind(this)),
+      );
+
+      this.topics.add(topic);
+    } catch (error) {
+      console.log(error);
+      this.logger.error('failed to register listener', { event: topic, error });
+    }
+  }
+
+  private async consumerCallback(err: NatsError | null, msg: JsMsg | null) {
+    if (err !== null) {
+      this.logger.error('error while receiving message', { error: err });
+      return;
+    } else if (msg === null) return;
+
+    try {
+      // TODO: extract trace parent and add to span context
+
+      const data = await msg.json();
+      this.emit(msg.subject, data);
+    } catch (e) {
+      this.logger.error('failed to deserialize message', { error: e });
+    } finally {
+      await msg.ack();
+    }
+  }
+}

--- a/src/lib/nats/client.ts
+++ b/src/lib/nats/client.ts
@@ -20,6 +20,7 @@ export default class NATS extends EventEmitter {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public override on(eventName: string | symbol, listener: (...args: any[]) => void): this {
     // intentionally ignoring promise
     this.listen(eventName.toString());
@@ -27,6 +28,7 @@ export default class NATS extends EventEmitter {
     return super.on(eventName, listener);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public override once(eventName: string | symbol, listener: (...args: any[]) => void): this {
     // intentionally ignoring promise
     this.listen(eventName.toString());

--- a/src/lib/nats/events.ts
+++ b/src/lib/nats/events.ts
@@ -1,0 +1,6 @@
+/**
+ * Fired on workshops.automated.updated and workshops.automated.deleted
+ */
+export interface EventChanged {
+  event_id: number;
+}

--- a/src/lib/nats/index.ts
+++ b/src/lib/nats/index.ts
@@ -1,0 +1,7 @@
+import NATS from './client';
+
+const nats = new NATS();
+
+export * from './events';
+
+export default nats;

--- a/src/lib/portal.ts
+++ b/src/lib/portal.ts
@@ -63,6 +63,7 @@ export interface EventDetails {
   id: number;
   name: string;
   url: string;
+  description: string | null;
   start: string;
   end: string;
 }

--- a/src/lib/scheduled-events.ts
+++ b/src/lib/scheduled-events.ts
@@ -14,6 +14,7 @@ export async function create(client: Client, details: EventDetails) {
   const guild = await client.guilds.fetch(GUILD_ID);
   const created = await guild.scheduledEvents.create({
     name: details.name,
+    description: details.description || undefined,
     scheduledStartTime: details.start,
     scheduledEndTime: details.end,
     privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
@@ -37,6 +38,7 @@ export async function update(client: Client, details: EventDetails, scheduledEve
 
   const eventOptions = {
     name: details.name,
+    description: details.description || undefined,
     scheduledStartTime: details.start,
     scheduledEndTime: details.end,
     privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,

--- a/src/lib/scheduled-events.ts
+++ b/src/lib/scheduled-events.ts
@@ -1,0 +1,70 @@
+import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } from 'discord-api-types/v10';
+import { Client } from 'discord.js';
+
+import { GUILD_ID } from '@lib/config';
+import { Event } from '@lib/database';
+import { EventDetails } from '@lib/portal';
+
+/**
+ * Create a new scheduled event
+ * @param client the discord client
+ * @param details the event details
+ */
+export async function create(client: Client, details: EventDetails) {
+  const guild = await client.guilds.fetch(GUILD_ID);
+  const created = await guild.scheduledEvents.create({
+    name: details.name,
+    scheduledStartTime: details.start,
+    scheduledEndTime: details.end,
+    privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+    entityType: GuildScheduledEventEntityType.External,
+    entityMetadata: {
+      location: details.url,
+    },
+  });
+
+  await Event.create(details.id, created.id);
+}
+
+/**
+ * Update a scheduled event
+ * @param client the discord client
+ * @param details the changed event details
+ * @param scheduledEventId the scheduled event id
+ */
+export async function update(client: Client, details: EventDetails, scheduledEventId: string) {
+  const guild = await client.guilds.fetch(GUILD_ID);
+
+  const eventOptions = {
+    name: details.name,
+    scheduledStartTime: details.start,
+    scheduledEndTime: details.end,
+    privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+    entityType: GuildScheduledEventEntityType.External,
+    entityMetadata: {
+      location: details.url,
+    },
+  };
+
+  try {
+    await guild.scheduledEvents.edit(scheduledEventId, eventOptions);
+  } catch {
+    const created = await guild.scheduledEvents.create(eventOptions);
+    await Event.create(details.id, created.id);
+  }
+}
+
+/**
+ * Delete a scheduled event
+ * @param client the discord client
+ * @param scheduledEventId the scheduled event id
+ */
+export async function remove(client: Client, scheduledEventId: string) {
+  try {
+    const guild = await client.guilds.fetch(GUILD_ID);
+    await guild.scheduledEvents.delete(scheduledEventId);
+  } catch {}
+
+  // Delete the mapping no matter what happens with Discord
+  await Event.delete(scheduledEventId);
+}

--- a/src/listeners/event-deleted.ts
+++ b/src/listeners/event-deleted.ts
@@ -1,0 +1,26 @@
+import { GUILD_ID } from '@lib/config';
+import { Event } from '@lib/database';
+import nats, { EventChanged } from '@lib/nats';
+import { Listener } from '@lib/sapphire';
+
+export class EventDeleted extends Listener {
+  public constructor(context: Listener.Context, options: Listener.Options) {
+    super(context, {
+      ...options,
+      emitter: nats,
+      event: 'workshops.automated.deleted',
+    });
+  }
+
+  public override async run(data: EventChanged) {
+    const discordId = await Event.find(data.event_id);
+    if (discordId === null) return;
+
+    try {
+      const guild = await this.container.client.guilds.fetch(GUILD_ID);
+      await guild.scheduledEvents.delete(discordId);
+    } catch {}
+
+    await Event.delete(discordId);
+  }
+}

--- a/src/listeners/event-deleted.ts
+++ b/src/listeners/event-deleted.ts
@@ -1,7 +1,7 @@
-import { GUILD_ID } from '@lib/config';
 import { Event } from '@lib/database';
 import nats, { EventChanged } from '@lib/nats';
 import { Listener } from '@lib/sapphire';
+import * as scheduledEvents from '@lib/scheduled-events';
 
 export class EventDeleted extends Listener {
   public constructor(context: Listener.Context, options: Listener.Options) {
@@ -16,11 +16,6 @@ export class EventDeleted extends Listener {
     const discordId = await Event.find(data.event_id);
     if (discordId === null) return;
 
-    try {
-      const guild = await this.container.client.guilds.fetch(GUILD_ID);
-      await guild.scheduledEvents.delete(discordId);
-    } catch {}
-
-    await Event.delete(discordId);
+    await scheduledEvents.remove(this.container.client, discordId);
   }
 }

--- a/src/listeners/event-updated.ts
+++ b/src/listeners/event-updated.ts
@@ -1,0 +1,77 @@
+import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } from 'discord-api-types/v10';
+
+import { GUILD_ID } from '@lib/config';
+import { Event } from '@lib/database';
+import nats, { EventChanged } from '@lib/nats';
+import { EventDetails, findEvent } from '@lib/portal';
+import { Listener } from '@lib/sapphire';
+
+export class EventUpdated extends Listener {
+  public constructor(context: Listener.Context, options: Listener.Options) {
+    super(context, {
+      ...options,
+      emitter: nats,
+      event: 'workshops.automated.updated',
+    });
+  }
+
+  public override async run(data: EventChanged) {
+    const details = await findEvent(data.event_id);
+    const discordId = await Event.find(data.event_id);
+
+    // portal | discord | action
+    //    y   |    n    | create
+    //    n   |    n    | do nothing
+    //    y   |    y    | update
+    //    n   |    y    | delete
+
+    if (details !== null && discordId === null) await this.create(details);
+    else if (details !== null && discordId !== null) await this.update(details, discordId);
+    else if (details === null && discordId !== null) await this.delete(discordId);
+  }
+
+  private async create(details: EventDetails) {
+    const guild = await this.container.client.guilds.fetch(GUILD_ID);
+    const created = await guild.scheduledEvents.create({
+      name: details.name,
+      scheduledStartTime: details.start,
+      scheduledEndTime: details.end,
+      privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+      entityType: GuildScheduledEventEntityType.External,
+      entityMetadata: {
+        location: details.url,
+      },
+    });
+
+    await Event.create(details.id, created.id);
+  }
+
+  private async update(details: EventDetails, discordId: string) {
+    try {
+      const guild = await this.container.client.guilds.fetch(GUILD_ID);
+      await guild.scheduledEvents.edit(discordId, {
+        name: details.name,
+        scheduledStartTime: details.start,
+        scheduledEndTime: details.end,
+        privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+        entityType: GuildScheduledEventEntityType.External,
+        entityMetadata: {
+          location: details.url,
+        },
+      });
+    } catch {
+      // Delete the mapping if we can't update the event
+      await Event.delete(discordId);
+    }
+  }
+
+  private async delete(discordId: string) {
+    try {
+      const guild = await this.container.client.guilds.fetch(GUILD_ID);
+      await guild.scheduledEvents.delete(discordId);
+    } catch {}
+
+    // Delete the mapping no matter what happens with Discord
+    await Event.delete(discordId);
+  }
+}

--- a/src/listeners/event-updated.ts
+++ b/src/listeners/event-updated.ts
@@ -1,10 +1,8 @@
-import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } from 'discord-api-types/v10';
-
-import { GUILD_ID } from '@lib/config';
 import { Event } from '@lib/database';
 import nats, { EventChanged } from '@lib/nats';
-import { EventDetails, findEvent } from '@lib/portal';
+import { findEvent } from '@lib/portal';
 import { Listener } from '@lib/sapphire';
+import * as scheduledEvents from '@lib/scheduled-events';
 
 export class EventUpdated extends Listener {
   public constructor(context: Listener.Context, options: Listener.Options) {
@@ -25,53 +23,10 @@ export class EventUpdated extends Listener {
     //    y   |    y    | update
     //    n   |    y    | delete
 
-    if (details !== null && discordId === null) await this.create(details);
-    else if (details !== null && discordId !== null) await this.update(details, discordId);
-    else if (details === null && discordId !== null) await this.delete(discordId);
-  }
+    const client = this.container.client;
 
-  private async create(details: EventDetails) {
-    const guild = await this.container.client.guilds.fetch(GUILD_ID);
-    const created = await guild.scheduledEvents.create({
-      name: details.name,
-      scheduledStartTime: details.start,
-      scheduledEndTime: details.end,
-      privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
-      entityType: GuildScheduledEventEntityType.External,
-      entityMetadata: {
-        location: details.url,
-      },
-    });
-
-    await Event.create(details.id, created.id);
-  }
-
-  private async update(details: EventDetails, discordId: string) {
-    try {
-      const guild = await this.container.client.guilds.fetch(GUILD_ID);
-      await guild.scheduledEvents.edit(discordId, {
-        name: details.name,
-        scheduledStartTime: details.start,
-        scheduledEndTime: details.end,
-        privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
-        entityType: GuildScheduledEventEntityType.External,
-        entityMetadata: {
-          location: details.url,
-        },
-      });
-    } catch {
-      // Delete the mapping if we can't update the event
-      await Event.delete(discordId);
-    }
-  }
-
-  private async delete(discordId: string) {
-    try {
-      const guild = await this.container.client.guilds.fetch(GUILD_ID);
-      await guild.scheduledEvents.delete(discordId);
-    } catch {}
-
-    // Delete the mapping no matter what happens with Discord
-    await Event.delete(discordId);
+    if (details !== null && discordId === null) await scheduledEvents.create(client, details);
+    else if (details !== null && discordId !== null) await scheduledEvents.update(client, details, discordId);
+    else if (details === null && discordId !== null) await scheduledEvents.remove(client, discordId);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,6 +2393,13 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nats@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nats/-/nats-2.15.0.tgz#b56598a1d3dd3a00e35ee410e5f87b8b84cbf004"
+  integrity sha512-0E3dFfevPiTN691uuDroVb+a3U5XizSq1xupDMgthUd0o+40QEYzfodIK0DP9l7IH6PUu5JP1u+mzzQ2RGM/ug==
+  dependencies:
+    nkeys.js "1.0.5"
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -2402,6 +2409,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nkeys.js@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nkeys.js/-/nkeys.js-1.0.5.tgz#3024bde671eb33be0316ff2d5abe8b8cec960158"
+  integrity sha512-u25YnRPHiGVsNzwyHnn+PT90sgAhnS8jUJ1nxmkHMFYCJ6+Ic0lv291w7uhRBpJVJ3PH2GWbYqA151lGCRrB5g==
+  dependencies:
+    tweetnacl "1.0.3"
 
 node-cache@^5.1.2:
   version "5.1.2"
@@ -3123,6 +3137,11 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tweetnacl@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.21.0":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -1206,6 +1213,13 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@^3.2.7:
   version "3.2.7"
@@ -2704,6 +2718,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regexp.prototype.flags@^1.4.3:
   version "1.5.0"


### PR DESCRIPTION
This adds support for creating [Discord scheduled events](https://support.discord.com/hc/en-us/articles/4409494125719-Scheduled-Events) from the application portal. Commands were also added for listing the event schedule (`/schedule`), getting the next event (`/next`), and syncing the Discord and application portal events (`/sync-events`).

Creating listeners for NATS subscriptions was also added to listen for workshop update/delete events from the application portal.